### PR TITLE
Add LlamaIndex demo with Qdrant storage

### DIFF
--- a/docs/nlweb-hello-world.md
+++ b/docs/nlweb-hello-world.md
@@ -67,13 +67,14 @@ These instructions assume that you have Python 3.10+ installed locally.
 
     You can find even more data, including other formats other than RSS, in this [OneDrive folder](https://1drv.ms/f/c/6c6197aa87f7f4c4/EsT094eql2EggGxlBAAAAAABajQiZ5unf_Ri_OWksR8eNg?e=I4z5vw). (Note:  If it asks you to login, try the URL a 2nd time. It should be open permissions.)
 
-    For corporate documents you can run:
+    For corporate documents you can run the new demo script from the repo root:
 
     ```sh
-    python tools/llamaindex_demo.py
+    python tools/llamaindex_demo.py --docs ./docs
     ```
 
-    This indexes all `.docx` files in the `docs` folder and lets you query them interactively.
+    The script loads DOCX files, splits them into ~200–400 token chunks, stores the embeddings in Qdrant,
+    and starts an interactive prompt powered by GPT‑4o‑mini.
 
 7. Start your NLWeb server (again from the 'code' folder):
 

--- a/tools/llamaindex_demo.py
+++ b/tools/llamaindex_demo.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Example LlamaIndex pipeline for loading and querying DOCX files."""
+
+import argparse
+import os
+
+from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.core.node_parser import SentenceSplitter, SemanticSplitterNodePostprocessor
+from llama_index.core.query_engine import RetrieverQueryEngine
+from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.llms.azure_openai import AzureOpenAI
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from llama_index.core.postprocessor import SentenceTransformerRerank
+from qdrant_client import QdrantClient
+
+COLLECTION_NAME = "docx_demo"
+
+
+def build_index(doc_folder: str) -> VectorStoreIndex:
+    """Load DOCX files and build a vector index."""
+    azure_key = os.environ["AZURE_OPENAI_KEY"]
+    azure_endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
+    azure_version = os.getenv("AZURE_OPENAI_VERSION", "2024-02-01")
+
+    docs = SimpleDirectoryReader(doc_folder, required_exts=[".docx"]).load_data()
+
+    splitter = SentenceSplitter(chunk_size=300, chunk_overlap=50)
+    nodes = splitter.get_nodes_from_documents(docs)
+
+    post = SemanticSplitterNodePostprocessor(buffer_size=3, threshold=0.7)
+    nodes = post.postprocess_nodes(nodes)
+
+    embed_model = AzureOpenAIEmbedding(
+        model="text-embedding-3-large",
+        api_key=azure_key,
+        azure_endpoint=azure_endpoint,
+        api_version=azure_version,
+    )
+
+    qdrant_client = QdrantClient(
+        url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+        api_key=os.getenv("QDRANT_API_KEY"),
+    )
+    vector_store = QdrantVectorStore(client=qdrant_client, collection_name=COLLECTION_NAME)
+
+    return VectorStoreIndex(nodes, embed_model=embed_model, vector_store=vector_store)
+
+
+def query_loop(index: VectorStoreIndex, top_k: int, rerank: bool) -> None:
+    """Interactive query loop using GPT-4o-mini."""
+    azure_key = os.environ["AZURE_OPENAI_KEY"]
+    azure_endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
+    azure_version = os.getenv("AZURE_OPENAI_VERSION", "2024-02-01")
+
+    llm = AzureOpenAI(
+        model="gpt-4o-mini",
+        api_key=azure_key,
+        azure_endpoint=azure_endpoint,
+        api_version=azure_version,
+    )
+
+    retriever = index.as_retriever(similarity_top_k=top_k)
+    postprocessors = [SentenceTransformerRerank()] if rerank else None
+    engine = RetrieverQueryEngine.from_args(retriever, llm=llm, node_postprocessors=postprocessors)
+
+    while True:
+        query = input("Query> ").strip()
+        if not query:
+            break
+        response = engine.query(query)
+        print(response)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Index DOCX files with LlamaIndex")
+    parser.add_argument("--docs", default="./docs", help="Folder containing DOCX files")
+    parser.add_argument("--top_k", type=int, default=3, help="Number of nodes to retrieve")
+    parser.add_argument("--rerank", action="store_true", help="Apply a reranker to retrieved nodes")
+    args = parser.parse_args()
+
+    index = build_index(args.docs)
+    query_loop(index, args.top_k, args.rerank)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/llamaindex_demo.py` demo to index DOCX files with LlamaIndex
- update hello world docs with instructions for the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684310a8b0fc8330996f6af13ae2a4bf