### PR TITLE
Use env vars for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ We expect most production deployments to use their own UI. They are also likely 
 - Running it on GCP... coming soon
 - Running it AWS... coming soon
 
+### Environment Variables
+
+Copy `code/.env.template` to `.env` and set the following variables before
+running the server:
+
+- `AZURE_OPENAI_KEY` – Azure OpenAI API key
+- `AZURE_OPENAI_ENDPOINT` – base URL of your Azure OpenAI resource
+- `AZURE_OPENAI_VERSION` – API version to use
+- `QDRANT_LOCAL_PATH` – local path for Qdrant (optional)
+- `QDRANT_URL` – remote Qdrant server URL (optional)
+- `QDRANT_API_KEY` – API key for remote Qdrant (optional)
+- `NLWEB_OUTPUT_DIR` – directory for logs and data (optional)
+- `NLWEB_LOGGING_PROFILE` – logging configuration profile
+
 ### NLWeb
 
 - [Life of a Chat Query](docs/life-of-a-chat-query.md)

--- a/code/config/config.py
+++ b/code/config/config.py
@@ -160,13 +160,16 @@ class AppConfig:
                     high=self._get_config_value(m.get("high")),
                     low=self._get_config_value(m.get("low"))
                 ) if m else None
-                
-                # Extract configuration values from the YAML with the new method
-                api_key = self._get_config_value(cfg.get("api_key_env"))
-                api_endpoint = self._get_config_value(cfg.get("api_endpoint_env"))
-                api_version = self._get_config_value(cfg.get("api_version_env"))
+
+                # Environment variable names are stored in the YAML
+                api_key_env = cfg.get("api_key_env")
+                api_key = os.getenv(api_key_env) if api_key_env else None
+                endpoint_env = cfg.get("api_endpoint_env")
+                api_endpoint = os.getenv(endpoint_env) if endpoint_env else None
+                version_env = cfg.get("api_version_env")
+                api_version = os.getenv(version_env) if version_env else None
                 llm_type = self._get_config_value(cfg.get("llm_type"))
-                # Create the LLM provider config - no longer include embedding model
+
                 self.llm_endpoints[name] = LLMProviderConfig(
                     llm_type=llm_type,
                     api_key=api_key,
@@ -198,12 +201,14 @@ class AppConfig:
 
         for name, cfg in data.get("providers", {}).items():
             # Extract configuration values from the YAML
-            api_key = self._get_config_value(cfg.get("api_key_env"))
-            api_endpoint = self._get_config_value(cfg.get("api_endpoint_env"))
-            api_version = self._get_config_value(cfg.get("api_version_env"))
+            api_key_env = cfg.get("api_key_env")
+            api_key = os.getenv(api_key_env) if api_key_env else None
+            endpoint_env = cfg.get("api_endpoint_env")
+            api_endpoint = os.getenv(endpoint_env) if endpoint_env else None
+            version_env = cfg.get("api_version_env")
+            api_version = os.getenv(version_env) if version_env else None
             model = self._get_config_value(cfg.get("model"))
 
-            # Create the embedding provider config
             self.embedding_providers[name] = EmbeddingProviderConfig(
                 api_key=api_key,
                 endpoint=api_endpoint,


### PR DESCRIPTION
## Summary
- load provider secrets via `os.getenv`
- document environment variables in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843109e8bdc8330b030bd43f8d7f3a0